### PR TITLE
placeholder should be 32bytes, not 4

### DIFF
--- a/treehasher.go
+++ b/treehasher.go
@@ -92,5 +92,5 @@ func (th *treeHasher) pathSize() int {
 }
 
 func (th *treeHasher) placeholder() []byte {
-	return bytes.Repeat([]byte{0}, th.pathSize())
+	return bytes.Repeat([]byte{0}, th.hasher.Size())
 }


### PR DESCRIPTION
original code pathSize equals hasher.Size so it's ok but in our case, path is only 4bytes but hash result is still 32bytes